### PR TITLE
Uppercase the selection string before parsing it

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,6 +76,7 @@ def genEdFinder(selection):
     
     # Formats selection input from url to be used
     selection = selection.replace(" ", "")
+    selection = selection.upper()
     selection = list(selection)
     
     courses = [[],[],[],[],[],[]]  # List of area course lists, B through G


### PR DESCRIPTION
Uppercase the selection string before parsing it so upper and lowercase can be used by the user.

Tested:
- exact matches
- secondary matches
- multi-case selection (e.g. "dF")